### PR TITLE
Document movies jsx

### DIFF
--- a/src/pages/Movies/Movies.jsx
+++ b/src/pages/Movies/Movies.jsx
@@ -1,8 +1,14 @@
+// Movies page component for FakeFlix.
+// fade‑in animations via Framer Motion.
 import "./movies.scss"
+// Renders the movies landing page with a banner, multiple rows of movie categories,
 import Banner from "../../components/Banner/Banner"
 import Row from "../../components/Row/Row"
+// and a footer credit. Uses the custom hook `useRetrieveData('movies')` to retrieve
 import Credits from "../../components/Credits/Credits";
+// configuration for each row and passes it to the Row component. Includes page
 import { useRetrieveData } from "../../hooks/useRetrieveData";
+// fade‑in animations via Framer Motion.
 import { motion } from "framer-motion";
 import { defaultPageFadeInVariants } from "../../motionUtils";
 

--- a/src/pages/Movies/Movies.jsx
+++ b/src/pages/Movies/Movies.jsx
@@ -22,8 +22,8 @@ import { defaultPageFadeInVariants } from "../../motionUtils";
 
 
 const Movies = () => {
-    // Retrieve configuration objects for each movie category (row).
-    // Each config includes a Redux selector and metadata used by the Row component.
+   // Pull structured row configs (ids, selectors, titles, etc.) for the Movies page.
+    // These configs are derived from `fetchMovieDataConfig` and power each <Row />.
     const rows = useRetrieveData('movies');
 
     return (
@@ -33,8 +33,8 @@ const Movies = () => {
             initial="initial"
             animate="animate"
             exit="exit"
-            //Render a hero banner featuring a random trending movie.
-            //Loop through each row configuration and render the corresponding Row. Spread the configuration object so that Row receives all required props: id, title, genre, selector, and isLarge.
+            // Hero banner for Movies. With type='movies', Banner selects trending movies from Redux (selectTrendingMovies), randomizes one item, truncates its overview, shows Play/More Info actions, and uses BASE_IMG_URL for backdrop. 
+            //Render one Row per config. Each config includes:- title/genre: used for the section header and route link (/movies/:genre) - selector: Redux selector Row uses to read {loading, error, data}- isLarge: optional larger poster style for certain rows (e.g., Originals)The Row handles skeletons, Swiper navigation, and responsive breakpoints. 
             //Display footer credits acknowledging the developer th3wall
         >
             <Banner type='movies' />

--- a/src/pages/Movies/Movies.jsx
+++ b/src/pages/Movies/Movies.jsx
@@ -12,7 +12,10 @@ import { useRetrieveData } from "../../hooks/useRetrieveData";
 import { motion } from "framer-motion";
 import { defaultPageFadeInVariants } from "../../motionUtils";
 
+
 const Movies = () => {
+    // Retrieve configuration objects for each movie category (row).
+    // Each config includes a Redux selector and metadata used by the Row component.
     const rows = useRetrieveData('movies');
 
     return (
@@ -22,6 +25,8 @@ const Movies = () => {
             initial="initial"
             animate="animate"
             exit="exit"
+            //Render a hero banner featuring a random trending movie.
+            //Loop through each row configuration and render the corresponding Row. Spread the configuration object so that Row receives all required props: id, title, genre, selector, and isLarge.
         >
             <Banner type='movies' />
             {rows && rows.map(props => (
@@ -31,5 +36,4 @@ const Movies = () => {
         </motion.div>
     )
 }
-
 export default Movies

--- a/src/pages/Movies/Movies.jsx
+++ b/src/pages/Movies/Movies.jsx
@@ -1,3 +1,19 @@
+/**
+ * Movies page component for FakeFlix.
+ *
+ * - Retrieves row configurations via `useRetrieveData('movies')`. Under the hood,
+ *   this selects `fetchMovieDataConfig` (see dataConfig.js), dispatches each
+ *   row’s thunk (e.g., fetchTrendingMoviesAsync) with its endpoint, and returns
+ *   metadata (id/title/genre/selector/isLarge) for rendering.
+ * - Displays a Banner configured for movies (random trending pick + actions).
+ * - Maps each row config to a <Row />. Row uses the provided `selector` to
+ *   read its Redux slice (loading/error/results) and renders a Swiper carousel.
+ * - Adds Credits at the bottom. The whole page is wrapped in a motion.div that
+ *   applies `defaultPageFadeInVariants` for page transitions.
+ */
+
+
+
 // Movies page component for FakeFlix.
 // fade‑in animations via Framer Motion.
 import "./movies.scss"

--- a/src/pages/Movies/Movies.jsx
+++ b/src/pages/Movies/Movies.jsx
@@ -1,14 +1,22 @@
 // Movies page component for FakeFlix.
 // fade‑in animations via Framer Motion.
 import "./movies.scss"
-// Renders the movies landing page with a banner, multiple rows of movie categories,
+// Renders the hero area. With type="movies", it selects trending movies
+// from Redux (via selectTrendingMovies) and picks a random item to feature.
 import Banner from "../../components/Banner/Banner"
+// Renders a horizontally scrollable slider for a movie category.
+// Each Row consumes a Redux selector (from the config) to read its slice,
+// shows skeletons while loading, and uses Swiper for the carousel.
 import Row from "../../components/Row/Row"
-// and a footer credit. Uses the custom hook `useRetrieveData('movies')` to retrieve
+// Footer with developer credit; animated in with creditsFadeInUpVariants.
 import Credits from "../../components/Credits/Credits";
-// configuration for each row and passes it to the Row component. Includes page
+
+// Custom hook that (1) chooses the proper dataConfig array for "movies",
+// (2) dispatches each row’s thunk with its URL (isPage=true),
+// and (3) returns an array of row configs: { id, title, genre, selector, isLarge }.
 import { useRetrieveData } from "../../hooks/useRetrieveData";
-// fade‑in animations via Framer Motion.
+// Shared animation variants. defaultPageFadeInVariants provides a simple fade
+// for initial/animate/exit, consistent with other pages (see motionUtils.js).
 import { motion } from "framer-motion";
 import { defaultPageFadeInVariants } from "../../motionUtils";
 
@@ -27,6 +35,7 @@ const Movies = () => {
             exit="exit"
             //Render a hero banner featuring a random trending movie.
             //Loop through each row configuration and render the corresponding Row. Spread the configuration object so that Row receives all required props: id, title, genre, selector, and isLarge.
+            //Display footer credits acknowledging the developer th3wall
         >
             <Banner type='movies' />
             {rows && rows.map(props => (


### PR DESCRIPTION
This pull request documents the Movies.jsx file located in src/pages/Movies/Movies.jsx.
The goal of this PR is to improve code readability and maintainability by explaining the purpose and behavior of the Movies page component, its imports, and its integration with other parts of the FakeFlix codebase.

Changes Made

Added a file-level comment block summarizing the overall functionality of the Movies page:

Explains how it uses useRetrieveData('movies') to dispatch thunks from fetchMovieDataConfig and build row configurations.

Describes how the page renders a Banner, a list of Row components, and the Credits footer.

Notes that the entire page is wrapped in a motion.div using defaultPageFadeInVariants for fade-in transitions.

Added import-level comments explaining the role of each imported module (e.g., Banner logic, Row carousel, motion variants, Redux selectors).

Added a component-level comment detailing the workflow of the Movies component (retrieving configs, mapping rows, rendering child components).

Included inline comments within the JSX return block describing the behavior of Banner, Row, and Credits in detail.

Linked Issue

